### PR TITLE
fix: add tests and cancelOperation by reference

### DIFF
--- a/src/QueueLink.test.ts
+++ b/src/QueueLink.test.ts
@@ -88,4 +88,13 @@ describe('OnOffLink', () => {
             },
         );
     });
+
+    it('removes operations from the queue that are cancelled while closed', () => {
+        onOffLink.close();
+        const observable = execute(link, op);
+        const subscriber = observable.subscribe(() => {})
+        subscriber.unsubscribe();
+        onOffLink.open();
+        expect(testLink.operations.length).toBe(0);
+    });
 });

--- a/src/QueueLink.ts
+++ b/src/QueueLink.ts
@@ -35,8 +35,9 @@ export default class QueueLink extends ApolloLink {
             return forward(operation);
         }
         return new Observable(observer => {
-            this.enqueue({ operation, forward, observer });
-            return () => this.cancelOperation({ operation, forward, observer });
+            const operationEntry = { operation, forward, observer };
+            this.enqueue(operationEntry);
+            return () => this.cancelOperation(operationEntry);
         });
     }
 


### PR DESCRIPTION
Currently watchers were firing for screens that were no longer mounted, This would cause our server to receive a boat load of requests when the user was navigating around a lot whilst offline

This will now only issue to the network for queries with active subs