### PR TITLE
Add possibility to skip the queue

### DIFF
--- a/src/QueueLink.test.ts
+++ b/src/QueueLink.test.ts
@@ -49,6 +49,27 @@ describe('OnOffLink', () => {
             jest.runAllTimers();
         });
     });
+    it('skips the queue when asked to', () => {
+        const opWithSkipQueue: GraphQLRequest = {
+            query: gql`{ hello }`,
+            context: {
+                skipQueue: true,
+            },
+        };
+        onOffLink.close();
+        return new Promise((resolve, reject) => {
+            execute(link, opWithSkipQueue).subscribe({
+                next: (data) => undefined,
+                error: (error) => reject(error),
+                complete: () => {
+                    expect(testLink.operations.length).toBe(1);
+                    expect(testLink.operations[0].query).toEqual(op.query);
+                    resolve();
+                },
+            });
+            jest.runAllTimers();
+        });
+    });
     it('passes through errors', () => {
         const testError = new Error('Hello darkness my old friend');
         const opWithError: GraphQLRequest = {

--- a/src/QueueLink.ts
+++ b/src/QueueLink.ts
@@ -34,6 +34,9 @@ export default class QueueLink extends ApolloLink {
         if (this.isOpen) {
             return forward(operation);
         }
+        if (operation.getContext().skipQueue) {
+            return forward(operation);
+        }
         return new Observable(observer => {
             const operationEntry = { operation, forward, observer };
             this.enqueue(operationEntry);


### PR DESCRIPTION
We use ApolloLinkQueue for offline mutations support, but sometimes we want to be able to skip the queue.