### PR TITLE
implement deduplication options

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ const offlineLink = new QueueLink({
 });
 
 this.link = ApolloLink.from([
+    new RetryLink({
+      attempts: {
+        // We don't want to retry deduped operations
+        retryIf: (error, _operation) => !!error && error.name !== 'DedupedByQueueError'
+      }
+    }),
     offlineLink,
     new BatchHttpLink({ uri: URI_TO_YOUR_GRAPHQL_SERVER }),
 ]);

--- a/src/QueueLink.test.ts
+++ b/src/QueueLink.test.ts
@@ -1,4 +1,6 @@
-import QueueLink from './QueueLink';
+import QueueLink, {
+    DedupedByQueueError
+} from './QueueLink';
 import {
     assertObservableSequence,
     executeMultiple,
@@ -133,6 +135,7 @@ describe('OnOffLink', () => {
         return assertObservableSequence(
             executeMultiple(myLink, op, op2, op),
             [
+                { type: 'error', value: new DedupedByQueueError()},
                 { type: 'next', value: testResponse2 },
                 { type: 'next', value: testResponse },
                 { type: 'complete' },
@@ -153,6 +156,7 @@ describe('OnOffLink', () => {
         return assertObservableSequence(
             executeMultiple(myLink, op, op2, op),
             [
+                { type: 'error', value: new DedupedByQueueError()},
                 { type: 'next', value: testResponse },
                 { type: 'next', value: testResponse2 },
                 { type: 'complete' },

--- a/src/QueueLink.test.ts
+++ b/src/QueueLink.test.ts
@@ -67,7 +67,7 @@ describe('OnOffLink', () => {
     });
     it('skips the queue when asked to', () => {
         const opWithSkipQueue: GraphQLRequest = {
-            query: gql`{ hello }`,
+            query: gql`query hello { hello }`,
             context: {
                 skipQueue: true,
             },

--- a/src/QueueLink.ts
+++ b/src/QueueLink.ts
@@ -14,9 +14,50 @@ interface OperationQueueEntry {
     subscription?: { unsubscribe: () => void };
 }
 
+export type KeepPolicy =
+    | 'first'
+    | 'last'
+    | 'all';
+
+export namespace QueueLink {
+    export interface Options {
+        /**
+         * Decides which entry to keep in the queue in case of duplicate entries.
+         *
+         * Defaults to 'all'.
+         */
+        keepPolicy?: KeepPolicy;
+
+        /**
+         * Specifies which entries are considered duplicates
+         *
+         * Defaults to comparing operation operationA.toKey() === operationB.toKey()
+         * https://www.apollographql.com/docs/link/overview.html
+         */
+        isDuplicate?: (operationA: Operation, operationB: Operation) => boolean;
+    }
+}
+
+const defaultOptions: QueueLink.Options = {
+    keepPolicy: 'all',
+    isDuplicate: (a: Operation, b: Operation) => a.toKey() === b.toKey()
+};
+
 export default class QueueLink extends ApolloLink {
     private opQueue: OperationQueueEntry[] = [];
     private isOpen: boolean = true;
+    private readonly keepPolicy: KeepPolicy;
+    private readonly isDuplicate: (operationA: Operation, operationB: Operation) => boolean;
+
+    constructor(options: QueueLink.Options = defaultOptions) {
+        super();
+        const {
+            keepPolicy = defaultOptions.keepPolicy,
+            isDuplicate = defaultOptions.isDuplicate
+        } = options;
+        this.keepPolicy = keepPolicy;
+        this.isDuplicate = isDuplicate;
+    }
 
     public open() {
         this.isOpen = true;
@@ -49,6 +90,29 @@ export default class QueueLink extends ApolloLink {
     }
 
     private enqueue(entry: OperationQueueEntry) {
-        this.opQueue.push(entry);
+        const isDuplicate = ({operation}: OperationQueueEntry) => this.isDuplicate(operation, entry.operation);
+        switch (this.keepPolicy) {
+            case "first":
+                const alreadyInQueue = this.opQueue.some(isDuplicate);
+                if (alreadyInQueue) {
+                    // if there is already a duplicate entry the new one gets ignored
+                    entry.observer.complete()
+                } else {
+                    this.opQueue.push(entry);
+                }
+                break;
+            case "last":
+                const index = this.opQueue.findIndex(isDuplicate);
+                if (index !== -1) {
+                    // if there is already a duplicate entry it gets removed
+                    const [duplicate] = this.opQueue.splice(index, 1);
+                    duplicate.observer.complete();
+                }
+                this.opQueue.push(entry);
+                break;
+            case "all":
+                this.opQueue.push(entry);
+                break;
+        }
     }
 }


### PR DESCRIPTION
Hey @helfer,

thanks for your awesome and simple queue link.
In our project we have the need to deduplicate operations.
Otherwise multiple operations of the same save mutation get batched into one call.

The implementation has no breaking changes, as it defaults to the same behavior as before.
If you would prefer to keep your queue link simple I'm happy to release this as a separat package.

There are two open questions:

Would you recommend another approach to cancel operations?
I currently just complete the observable.
Other options would be to return an error or just break the chain.
Or should there be an option to share the result like apollo-link-dedup does?

Is there a nicer way to test multiple operations?
I found no merge/concat methods and my executeMultiple functions seems a bit hacky.