### PR TITLE
Allow persistence and filtering

### DIFF
--- a/src/QueueLink.test.ts
+++ b/src/QueueLink.test.ts
@@ -130,4 +130,85 @@ describe('OnOffLink', () => {
         expect(testLink.operations.length).toBe(0);
     });
 
+
+    it('Test mutation filter', () => {
+        const onOffLinkFilter = new QueueLink({ filter: "mutation" });
+        onOffLinkFilter.close();
+        const filterLink = ApolloLink.from([onOffLinkFilter, testLink]);
+        execute(filterLink, op).subscribe({
+        });
+        jest.runAllTimers();
+        onOffLinkFilter.open();
+        expect(testLink.operations.length).toBe(0);
+    });
+
+    it('Test query filter', () => {
+        const onOffLinkFilter = new QueueLink({ filter: "query" });
+        onOffLinkFilter.close();
+        const filterLink = ApolloLink.from([onOffLinkFilter, testLink]);
+        execute(filterLink, op).subscribe({
+        });
+        jest.runAllTimers();
+        onOffLinkFilter.open();
+        expect(testLink.operations.length).toBe(1);
+    });
+
+
+    it('store test', () => {
+        let operations = [];
+        const storageEngine = {
+            getItem() {
+                return JSON.stringify(operations);
+            },
+            removeItem() {
+                operations = [];
+            },
+            setItem(key, content) {
+                console.log(content);
+                operations = JSON.parse(content);
+            }
+        };
+        const onOffLinkFilter = new QueueLink({
+            store: {
+                engine: storageEngine,
+                storeKey: "test"
+            }
+        });
+        onOffLinkFilter.close();
+        const filterLink = ApolloLink.from([onOffLinkFilter, testLink]);
+        execute(filterLink, op).subscribe({
+        });
+        jest.runAllTimers();
+        onOffLinkFilter.open();
+        expect(testLink.operations.length).toBe(1);
+    });
+
+    it('store test promises', () => {
+        let operations = [];
+        const storageEngine = {
+            getItem() {
+                return Promise.resolve(JSON.stringify(operations));
+            },
+            removeItem() {
+                operations = [];
+            },
+            setItem(key, content) {
+                console.log(content);
+                operations = JSON.parse(content);
+            }
+        };
+        const onOffLinkFilter = new QueueLink({
+            store: {
+                engine: storageEngine,
+                storeKey: "test"
+            }
+        });
+        onOffLinkFilter.close();
+        const filterLink = ApolloLink.from([onOffLinkFilter, testLink]);
+        execute(filterLink, op).subscribe({
+        });
+        jest.runAllTimers();
+        onOffLinkFilter.open();
+        expect(testLink.operations.length).toBe(1);
+    });
 });

--- a/src/QueueLink.test.ts
+++ b/src/QueueLink.test.ts
@@ -118,4 +118,16 @@ describe('OnOffLink', () => {
         onOffLink.open();
         expect(testLink.operations.length).toBe(0);
     });
+
+
+    it('filters op', () => {
+        const onOffLinkFilter = new QueueLink({ filter: "mutation" });
+        onOffLinkFilter.close();
+        const filterLink = ApolloLink.from([onOffLinkFilter, testLink]);
+        execute(filterLink, op).subscribe({
+        });
+        jest.runAllTimers();
+        expect(testLink.operations.length).toBe(0);
+    });
+
 });

--- a/src/QueueLink.ts
+++ b/src/QueueLink.ts
@@ -117,26 +117,20 @@ export default class QueueLink extends ApolloLink {
     }
 
     private matchesOperation(filter: string, operation: Operation): boolean {
-        if (operation.query && operation.query.definitions) {
-            return operation.query.definitions.filter((e) => {
-                return (e as any).operation === filter
-            }).length > 0;
-        } else {
-            return false;
-        }
+        return operation.query.definitions.filter((e) => {
+            return (e as any).operation === filter
+        }).length > 0;
     }
 
     private restoreDataFromStore() {
         if (this.store) {
-            const store = this.store.getItem(this.storeKey);
-            if (typeof store === 'string') {
-                this.opQueue = JSON.parse(store as string);
+            const savedData = this.store.getItem(this.storeKey);
+            if (typeof savedData === 'string') {
+                this.opQueue = JSON.parse(savedData as string);
             }
-            else {
-                store.then((data) => {
+            if (typeof savedData === 'object') {
+                savedData.then((data) => {
                     this.opQueue = JSON.parse(data);
-                }).catch((err) => {
-                    console.log(err);
                 });
             }
         }

--- a/src/QueueLink.ts
+++ b/src/QueueLink.ts
@@ -4,8 +4,16 @@ import {
     Operation,
     Observer,
     FetchResult,
-    NextLink,
+    NextLink
 } from 'apollo-link';
+
+export interface PersistentStore<T> {
+    getItem: (key: string) => Promise<T> | T;
+    setItem: (key: string, data: T) => Promise<void> | void;
+    removeItem: (key: string) => Promise<void> | void;
+}
+
+export type PersistedData = string | null;
 
 interface OperationQueueEntry {
     operation: Operation;
@@ -14,9 +22,44 @@ interface OperationQueueEntry {
     subscription?: { unsubscribe: () => void };
 }
 
+/**
+ * Initialization options for QueueLink
+ */
+interface QueueLinkOptions {
+    /**
+     * store used to persist queue. 
+     */
+    store?: {
+        // window.localstore, AsyncStore or anything that conforms to interface
+        engine: PersistentStore<PersistedData>,
+        // key used to store data
+        storeKey: string | "apollo-link-queue"
+    },
+    /**
+     * Queue only specific operations
+     **/
+    filter?: "mutation" | "query"
+}
+
 export default class QueueLink extends ApolloLink {
     private opQueue: OperationQueueEntry[] = [];
     private isOpen: boolean = true;
+
+    private store: PersistentStore<string>;
+    private filter: string;
+    private storeKey: string;
+
+    public constructor(options?: QueueLinkOptions) {
+        super()
+        if (options) {
+            if (options.store) {
+                this.store = options.store.engine;
+                this.storeKey = options.store.storeKey;
+                this.restoreDataFromStore();
+            }
+            this.filter = options.filter
+        }
+    }
 
     public open() {
         this.isOpen = true;
@@ -24,13 +67,16 @@ export default class QueueLink extends ApolloLink {
             forward(operation).subscribe(observer);
         });
         this.opQueue = [];
+        if (this.store) {
+            this.store.removeItem(this.storeKey)
+        }
     }
 
     public close() {
         this.isOpen = false;
     }
 
-    public request(operation: Operation, forward: NextLink ) {
+    public request(operation: Operation, forward: NextLink) {
         if (this.isOpen) {
             return forward(operation);
         }
@@ -46,9 +92,53 @@ export default class QueueLink extends ApolloLink {
 
     private cancelOperation(entry: OperationQueueEntry) {
         this.opQueue = this.opQueue.filter(e => e !== entry);
+        this.storeQueue();
+    }
+
+    private storeQueue() {
+        if (this.store) {
+            this.store.setItem(this.storeKey, JSON.stringify(this.opQueue));
+        }
     }
 
     private enqueue(entry: OperationQueueEntry) {
+        if (this.filter) {
+            if (this.matchesOperation(this.filter, entry.operation)) {
+                this.save(entry);
+            }
+        } else {
+            this.save(entry);
+        }
+    }
+
+    private save(entry: OperationQueueEntry) {
         this.opQueue.push(entry);
+        this.storeQueue();
+    }
+
+    private matchesOperation(filter: string, operation: Operation): boolean {
+        if (operation.query && operation.query.definitions) {
+            return operation.query.definitions.filter((e) => {
+                return (e as any).operation === filter
+            }).length > 0;
+        } else {
+            return false;
+        }
+    }
+
+    private restoreDataFromStore() {
+        if (this.store) {
+            const store = this.store.getItem(this.storeKey);
+            if (typeof store === 'string') {
+                this.opQueue = JSON.parse(store as string);
+            }
+            else {
+                store.then((data) => {
+                    this.opQueue = JSON.parse(data);
+                }).catch((err) => {
+                    console.log(err);
+                });
+            }
+        }
     }
 }


### PR DESCRIPTION
## Motivation

Allow queue persistence and filtering. 
Support use cases when:
- Queue should only process mutations
- Page was refreshed and queued elements will be removed

## Implementation

Using interface that can match local storage or any other platform storage
No extra packages
No change in current behavior (additional object passed to add extra storage and filter )

# TODO

More unit tests