### PR TITLE
Use observer from zen observable package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.1",
   "description": "A link to queue requests when a certain condition is met (eg. device is offline)",
   "dependencies": {
-    "apollo-link": "^0.7.0"
+    "apollo-link": "^1.2.3"
   },
   "devDependencies": {
     "@types/graphql": "^0.11.7",

--- a/src/QueueLink.ts
+++ b/src/QueueLink.ts
@@ -2,10 +2,10 @@ import {
     ApolloLink,
     Observable,
     Operation,
-    Observer,
     FetchResult,
     NextLink,
 } from 'apollo-link';
+import { Observer } from "zen-observable-ts";
 
 interface OperationQueueEntry {
     operation: Operation;


### PR DESCRIPTION
Use observer from zen observable package to compile link with latest version of apollo-link