### PR TITLE
Multiple same mutations ended up being executed at the same time thus ignoring the order of the queue

### DIFF
--- a/src/QueueLink.ts
+++ b/src/QueueLink.ts
@@ -2,7 +2,7 @@ import {
     ApolloLink,
     Operation,
     FetchResult,
-    NextLink,
+    NextLink
 } from '@apollo/client/link/core';
 import {
     Observable,
@@ -19,20 +19,17 @@ interface OperationQueueEntry {
 export default class QueueLink extends ApolloLink {
     private opQueue: OperationQueueEntry[] = [];
     private isOpen = true;
-
+    
     public open() {
         this.isOpen = true;
-        this.opQueue.forEach(({ operation, forward, observer }) => {
-            forward(operation).subscribe(observer);
-        });
-        this.opQueue = [];
+        this.opQueue[0].forward(this.opQueue[0].operation).subscribe(this.opQueue[0].observer);
     }
 
     public close() {
         this.isOpen = false;
     }
 
-    public request(operation: Operation, forward: NextLink) {
+    public request(operation: Operation, forward: NextLink){
         if (this.isOpen) {
             return forward(operation);
         }
@@ -48,9 +45,12 @@ export default class QueueLink extends ApolloLink {
 
     private cancelOperation(entry: OperationQueueEntry) {
         this.opQueue = this.opQueue.filter(e => e !== entry);
+        if(this.opQueue.length!==0)
+        this.opQueue[0].forward(this.opQueue[0].operation).subscribe(this.opQueue[0].observer);
     }
 
     private enqueue(entry: OperationQueueEntry) {
         this.opQueue.push(entry);
     }
+    
 }


### PR DESCRIPTION
Changed the queue to now process requests one at a time which solves the issue when multiple mutations are made in one batch